### PR TITLE
Add `Xoodoo[n_r]` Permutation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,18 @@ edition = "2021"
 
 [dependencies]
 crunchy = "=0.2.2"
+
+[dev-dependencies]
+rand = "=0.8.5"
+criterion = "=0.4.0"
+
+[features]
+dev = []
+
+[lib]
+bench = false
+
+[[bench]]
+name = "xoodoo"
+harness = false
+required-features = ["dev"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+crunchy = "=0.2.2"

--- a/benches/xoodoo.rs
+++ b/benches/xoodoo.rs
@@ -1,0 +1,32 @@
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use rand::{thread_rng, Rng};
+use xoofff::xoodoo;
+
+fn xoodoo<const ROUNDS: usize>(c: &mut Criterion) {
+    let mut rng = thread_rng();
+
+    let mut group = c.benchmark_group("xoodoo");
+    group.throughput(Throughput::Bytes(48)); // Xoodoo permutation works on 384 -bit wide state
+
+    group.bench_function(format!("xoodoo[{}] (cached)", ROUNDS), |bench| {
+        let mut state = [0u32; 12];
+        rng.fill(&mut state);
+
+        bench.iter(|| xoodoo::permute::<{ ROUNDS }>(black_box(&mut state)))
+    });
+    group.bench_function(format!("xoodoo[{}] (random)", ROUNDS), |bench| {
+        let mut state = [0u32; 12];
+        rng.fill(&mut state);
+
+        bench.iter_batched(
+            || state.clone(),
+            |mut state| xoodoo::permute::<{ ROUNDS }>(black_box(&mut state)),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+criterion_group!(permutation, xoodoo::<6>, xoodoo::<12>);
+criterion_main!(permutation);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
+#[cfg(feature = "dev")]
+pub mod xoodoo;
+#[cfg(not(feature = "dev"))]
 mod xoodoo;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+mod xoodoo;

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -32,3 +32,41 @@ fn cyclic_shift<const T: usize, const V: u32>(plane: &[u32]) -> [u32; 4] {
     }
     shifted
 }
+
+/// θ step mapping of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[inline(always)]
+fn theta(state: &mut [u32]) {
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let mut p = [0u32; 4];
+    unroll! {
+        for i in (0..12).step_by(4) {
+            p[0] ^= state[i + 0];
+            p[1] ^= state[i + 1];
+            p[2] ^= state[i + 2];
+            p[3] ^= state[i + 3];
+        }
+    }
+
+    let t0 = cyclic_shift::<1, 5>(&p);
+    let t1 = cyclic_shift::<1, 14>(&p);
+
+    let mut e = [0u32; 4];
+    unroll! {
+        for i in 0..4 {
+            e[i] = t0[i] ^ t1[i];
+        }
+    }
+
+    unroll! {
+        for i in (0..12).step_by(4) {
+            state[i + 0] ^= e[0];
+            state[i + 1] ^= e[1];
+            state[i + 2] ^= e[2];
+            state[i + 3] ^= e[3];
+        }
+    }
+}

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -100,3 +100,14 @@ fn rho_east(state: &mut [u32]) {
     state[4..8].copy_from_slice(&t0);
     state[8..12].copy_from_slice(&t1);
 }
+
+/// ι step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[inline(always)]
+fn iota(state: &mut [u32], ridx: usize) {
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    state[0] ^= RC[ridx]
+}

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -1,3 +1,5 @@
+use crunchy::unroll;
+
 /// Maximum number of rounds one can request to have when applying Xoodoo\[n_r\] permutation i.e. n_r <= MAX_ROUNDS
 ///
 /// See table 2 of https://ia.cr/2018/767
@@ -8,3 +10,25 @@ const RC: [u32; MAX_ROUNDS] = [
     0x00000058, 0x00000038, 0x000003c0, 0x000000d0, 0x00000120, 0x00000014, 0x00000060, 0x0000002c,
     0x00000380, 0x000000f0, 0x000001a0, 0x00000012,
 ];
+
+/// Given a plane of Xoodoo permutation state ( each plane has 4 lanes, each lane 32 -bit wide ),
+/// this routine function cyclically shifts the plane such that bit at position (x, z) is
+/// moved to (x+T, z+V).
+///
+/// Note, at bit index z = 0, least significant bit of each lane lives.
+/// See row 2 of table 1 of https://ia.cr/2018/767.
+#[inline(always)]
+fn cyclic_shift<const T: usize, const V: u32>(plane: &[u32]) -> [u32; 4] {
+    debug_assert!(
+        plane.len() == 4,
+        "Each lane of Xoodoo permutation state must have four lanes !"
+    );
+
+    let mut shifted = [0u32; 4];
+    unroll! {
+        for i in 0..4 {
+            shifted[(T + i) & 3usize] = plane[i].rotate_left(V);
+        }
+    }
+    shifted
+}

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -149,3 +149,19 @@ fn chi(state: &mut [u32]) {
         }
     }
 }
+
+/// Round function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[inline(always)]
+fn round(state: &mut [u32], ridx: usize) {
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+    debug_assert!(ridx < MAX_ROUNDS, "Round index must ∈ [0, MAX_ROUNDS) !");
+
+    theta(state);
+    rho_west(state);
+    iota(state, ridx);
+    chi(state);
+    rho_east(state);
+}

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -165,3 +165,22 @@ fn round(state: &mut [u32], ridx: usize) {
     chi(state);
     rho_east(state);
 }
+
+/// Xoodoo\[n_r\] permutation function s.t. n_r ( <= MAX_ROUNDS ) times round function
+/// is applied on permutation state, as described in algorithm 1 of https://ia.cr/2018/767.
+#[inline(always)]
+pub fn permute<const ROUNDS: usize>(state: &mut [u32]) {
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+    debug_assert!(
+        ROUNDS <= MAX_ROUNDS,
+        "Requested rounds must be < MAX_ROUNDS !"
+    );
+
+    let start = MAX_ROUNDS - ROUNDS;
+    for ridx in start..MAX_ROUNDS {
+        round(state, ridx);
+    }
+}

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -111,3 +111,41 @@ fn iota(state: &mut [u32], ridx: usize) {
 
     state[0] ^= RC[ridx]
 }
+
+/// χ step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[inline(always)]
+fn chi(state: &mut [u32]) {
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let mut b0 = [0u32; 4];
+    unroll! {
+        for i in 0..4 {
+            b0[i] = !state[4 + i] & state[8 + i];
+        }
+    }
+
+    let mut b1 = [0u32; 4];
+    unroll! {
+        for i in 0..4 {
+            b1[i] = !state[8 + i] & state[i];
+        }
+    }
+
+    let mut b2 = [0u32; 4];
+    unroll! {
+        for i in 0..4 {
+            b2[i] = !state[i] & state[4 + i];
+        }
+    }
+
+    unroll! {
+        for i in 0..4 {
+            state[i] ^= b0[i];
+            state[4 + i] ^= b1[i];
+            state[8 + i] ^= b2[i];
+        }
+    }
+}

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -1,0 +1,10 @@
+/// Maximum number of rounds one can request to have when applying Xoodoo\[n_r\] permutation i.e. n_r <= MAX_ROUNDS
+///
+/// See table 2 of https://ia.cr/2018/767
+const MAX_ROUNDS: usize = 12;
+
+/// Xoodoo\[n_r\] round constants, taken from table 2 of https://ia.cr/2018/767
+const RC: [u32; MAX_ROUNDS] = [
+    0x00000058, 0x00000038, 0x000003c0, 0x000000d0, 0x00000120, 0x00000014, 0x00000060, 0x0000002c,
+    0x00000380, 0x000000f0, 0x000001a0, 0x00000012,
+];

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -70,3 +70,33 @@ fn theta(state: &mut [u32]) {
         }
     }
 }
+
+/// ρ_west step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[inline(always)]
+fn rho_west(state: &mut [u32]) {
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let t0 = cyclic_shift::<1, 0>(&state[4..8]);
+    let t1 = cyclic_shift::<0, 11>(&state[8..12]);
+
+    state[4..8].copy_from_slice(&t0);
+    state[8..12].copy_from_slice(&t1);
+}
+
+/// ρ_east step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[inline(always)]
+fn rho_east(state: &mut [u32]) {
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let t0 = cyclic_shift::<0, 1>(&state[4..8]);
+    let t1 = cyclic_shift::<2, 8>(&state[8..12]);
+
+    state[4..8].copy_from_slice(&t0);
+    state[8..12].copy_from_slice(&t1);
+}


### PR DESCRIPTION
- [x] Add support for Xoodoo[n_r] permutation s.t. n_r <= 12 ( hidded behind `dev` feature gate )
- [x] Benchmark Xoodoo[n_r] permutation using criterion

```bash
RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench xoodoo --features="dev"
```

```bash
# On Macbook Pro with Intel i5-8279U CPU

xoodoo/xoodoo[6] (cached)
                        time:   [30.975 ns 31.082 ns 31.203 ns]
                        thrpt:  [1.4327 GiB/s 1.4382 GiB/s 1.4432 GiB/s]
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
xoodoo/xoodoo[6] (random)
                        time:   [34.180 ns 34.442 ns 34.736 ns]
                        thrpt:  [1.2869 GiB/s 1.2979 GiB/s 1.3079 GiB/s]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

xoodoo/xoodoo[12] (cached)
                        time:   [60.633 ns 60.813 ns 61.019 ns]
                        thrpt:  [750.20 MiB/s 752.74 MiB/s 754.97 MiB/s]
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
xoodoo/xoodoo[12] (random)
                        time:   [62.953 ns 63.334 ns 63.713 ns]
                        thrpt:  [718.47 MiB/s 722.77 MiB/s 727.15 MiB/s]
Found 7 outliers among 100 measurements (7.00%)
  6 (6.00%) high mild
  1 (1.00%) high severe
```