### PR TITLE
SIMD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crunchy = "=0.2.2"
 [dev-dependencies]
 rand = "=0.8.5"
 test-case = "=3.1.0"
-criterion = "=0.4.0"
+criterion = "=0.5.1"
 hex = "=0.4.3"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hex = "=0.4.3"
 
 [features]
 dev = []
+simd = []
 
 [lib]
 bench = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(portable_simd)]
+
 mod rolling;
 
 #[cfg(feature = "dev")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(portable_simd)]
+#![cfg_attr(feature = "simd", feature(portable_simd))]
 
 mod rolling;
 
@@ -7,8 +7,17 @@ pub mod xoodoo;
 #[cfg(not(feature = "dev"))]
 mod xoodoo;
 
+#[allow(unused)]
 mod xoofff;
+
+#[cfg(not(feature = "simd"))]
 pub use crate::xoofff::Xoofff;
+
+#[cfg(feature = "simd")]
+mod simd;
+
+#[cfg(feature = "simd")]
+pub use crate::simd::Xoofff;
 
 #[cfg(test)]
 mod tests;

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -1,0 +1,39 @@
+mod xoodoo;
+
+// target_arch || target_feature || x   || runtime detection possible
+// wasm32      || simd128        || x4  || no, make two modules
+// x86/x86_64  || avx2           || x8  || yes
+// x86/x86_64  || avx512         || x16 || yes
+
+#[cfg(feature = "dev")]
+pub use xoodoo::permutex;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx512"
+))]
+mod x16;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx512"
+))]
+pub use x16::Xoofff;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx2"
+))]
+mod x8;
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx2"
+))]
+pub use x8::Xoofff;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+mod x4;
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+pub use x4::Xoofff;

--- a/src/simd/x16.rs
+++ b/src/simd/x16.rs
@@ -1,10 +1,16 @@
+use super::xoodoo;
 use crate::rolling;
-use crate::xoodoo;
+use crate::xoodoo as serial_xoodoo;
+use crate::xoofff::{bytes_to_le_words, pad10x, words_to_le_bytes};
+use core::simd::{u32x16, SimdUint};
 use crunchy::unroll;
 use std::cmp;
 
-/// Xoodoo\[n_r\] being a 384 -bit permutation, messages are consumed in 48 -bytes chunks
+/// Xoodoo\[n_r\] being a 384-bit permutation messages are consumed in 48-byte chunks.
 const BLOCK_SIZE: usize = 48;
+
+/// The byte width of the parallel permutation.
+const PAR_BLOCK_SIZE: usize = BLOCK_SIZE * 16;
 
 /// \# -of rounds for Xoodoo permutation, see definition 3 of https://ia.cr/2018/767
 const ROUNDS: usize = 6;
@@ -26,16 +32,17 @@ const LANE_CNT: usize = BLOCK_SIZE / std::mem::size_of::<u32>();
 ///
 /// See https://ia.cr/2016/1188 for definition of Farfalle.
 /// Also see https://ia.cr/2018/767 for definition of Xoofff.
-#[derive(Clone, Copy)]
+///
+#[derive(Clone)]
 pub struct Xoofff {
-    imask: [u32; LANE_CNT], // input mask
-    omask: [u32; LANE_CNT], // output mask
-    acc: [u32; LANE_CNT],   // accumulator
-    iblk: [u8; BLOCK_SIZE], // input message block ( buffer )
-    oblk: [u8; BLOCK_SIZE], // output message block ( buffer )
-    ioff: usize,            // offset into input message block
-    ooff: usize,            // offset into output message block
-    finalized: usize,       // is deck function state finalized ?
+    imask: [u32; LANE_CNT],     // input mask
+    omask: [u32; LANE_CNT],     // output mask
+    acc: [u32x16; LANE_CNT],    // accumulator
+    iblk: [u8; PAR_BLOCK_SIZE], // input message block ( buffer )
+    oblk: [u8; PAR_BLOCK_SIZE], // output message block ( buffer )
+    ioff: usize,                // offset into input message block
+    ooff: usize,                // offset into output message block
+    finalized: usize,           // is deck function state finalized ?
 }
 
 impl Xoofff {
@@ -49,17 +56,16 @@ impl Xoofff {
             BLOCK_SIZE
         );
 
-        // masked key derivation phase
         let padded_key = pad10x(key);
         let mut masked_key = bytes_to_le_words(&padded_key);
-        xoodoo::permute::<ROUNDS>(&mut masked_key);
+        serial_xoodoo::permute::<ROUNDS>(&mut masked_key);
 
         Self {
             imask: masked_key,
             omask: [0u32; LANE_CNT],
-            acc: [0u32; LANE_CNT],
-            iblk: [0u8; BLOCK_SIZE],
-            oblk: [0u8; BLOCK_SIZE],
+            acc: [u32x16::splat(0u32); LANE_CNT],
+            iblk: [0u8; PAR_BLOCK_SIZE],
+            oblk: [0u8; PAR_BLOCK_SIZE],
             ioff: 0,
             ooff: 0,
             finalized: usize::MIN,
@@ -79,32 +85,52 @@ impl Xoofff {
             return;
         }
 
-        let blk_cnt = (self.ioff + msg.len()) / BLOCK_SIZE;
+        let par_blk_cnt = (self.ioff + msg.len()) / PAR_BLOCK_SIZE;
         let mut moff = 0;
 
-        for _ in 0..blk_cnt {
-            let byte_cnt = BLOCK_SIZE - self.ioff;
-
+        for _ in 0..par_blk_cnt {
+            let byte_cnt = PAR_BLOCK_SIZE - self.ioff;
             self.iblk[self.ioff..].copy_from_slice(&msg[moff..(moff + byte_cnt)]);
-            let mut words = bytes_to_le_words(&self.iblk);
 
-            debug_assert_eq!(LANE_CNT, 12);
+            let mut imasks = [[0u32; 12]; 16];
             unroll! {
-                for i in 0..12 {
-                    words[i] ^= self.imask[i];
+                for i in 0..16 {
+                    imasks[i] = self.imask;
+                    rolling::roll_xc(&mut self.imask);
                 }
             }
 
-            xoodoo::permute::<ROUNDS>(&mut words);
+            let imaskx = words_to_statex16(&imasks);
 
-            debug_assert_eq!(LANE_CNT, 12);
+            let mut words = [[0u32; 12]; 16];
             unroll! {
-                for i in 0..12 {
-                    self.acc[i] ^= words[i];
+                for i in 0..16 {
+                    words[i] = bytes_to_le_words(
+                        &self.iblk[i * BLOCK_SIZE..(i + 1) * BLOCK_SIZE]
+                            .try_into()
+                            .unwrap(),
+                    );
                 }
             }
 
-            rolling::roll_xc(&mut self.imask);
+            let mut states = words_to_statex16(&words);
+
+            debug_assert_eq!(LANE_CNT, 12);
+
+            unroll! {
+                for i in 0..12 {
+                    states[i] ^= imaskx[i];
+                }
+            }
+
+            xoodoo::permutex::<16, ROUNDS>(&mut states);
+
+            unroll! {
+                for i in 0..12 {
+                    self.acc[i] ^= states[i];
+                }
+            }
+
             moff += byte_cnt;
             self.ioff = 0;
         }
@@ -146,51 +172,83 @@ impl Xoofff {
         let mask = (1u8 << ds_bit_width) - 1u8;
         let pad_byte = (1u8 << ds_bit_width) | (domain_seperator & mask);
 
+        let blocks = self.ioff / BLOCK_SIZE + 1;
+
         self.iblk[self.ioff..].fill(0);
         self.iblk[self.ioff] = pad_byte;
 
-        let mut words = bytes_to_le_words(&self.iblk);
+        // Absorb the remainder in serial
+        let mut acc_final = [[0u32; 12]; 16];
+        for i in 0..blocks {
+            let mut words = bytes_to_le_words(
+                &self.iblk[i * BLOCK_SIZE..(i + 1) * BLOCK_SIZE]
+                    .try_into()
+                    .unwrap(),
+            );
 
-        debug_assert_eq!(LANE_CNT, 12);
+            debug_assert_eq!(LANE_CNT, 12);
+
+            unroll! {
+                for j in 0..12 {
+                    words[j] ^= self.imask[j];
+                }
+            }
+
+            serial_xoodoo::permute::<ROUNDS>(&mut words);
+
+            unroll! {
+                for j in 0..12 {
+                    acc_final[0][j] ^= words[j];
+                }
+            }
+
+            rolling::roll_xc(&mut self.imask);
+        }
+
+        let accx = words_to_statex16(&acc_final);
+
         unroll! {
             for i in 0..12 {
-                words[i] ^= self.imask[i];
+                self.acc[i] ^= accx[i];
             }
         }
 
-        xoodoo::permute::<ROUNDS>(&mut words);
-
-        debug_assert_eq!(LANE_CNT, 12);
-        unroll! {
-            for i in 0..12 {
-                self.acc[i] ^= words[i];
-            }
-        }
-
-        rolling::roll_xc(&mut self.imask);
         rolling::roll_xc(&mut self.imask);
 
         self.iblk.fill(0);
         self.ioff = 0;
         self.finalized = usize::MAX;
 
-        self.omask.copy_from_slice(&self.acc);
-        xoodoo::permute::<ROUNDS>(&mut self.omask);
+        unroll! {
+            for i in 0..12 {
+                self.omask[i] = self.acc[i].reduce_xor();
+            }
+        }
 
-        let mut words = self.omask;
-        xoodoo::permute::<ROUNDS>(&mut words);
+        serial_xoodoo::permute::<ROUNDS>(&mut self.omask);
+
+        let mut omasks = [[0u32; 12]; 16];
+        unroll! {
+            for i in 0..16 {
+                omasks[i] = self.omask;
+                rolling::roll_xe(&mut self.omask);
+            }
+        }
+
+        let mut states = words_to_statex16(&omasks);
+
+        xoodoo::permutex::<16, ROUNDS>(&mut states);
 
         debug_assert_eq!(LANE_CNT, 12);
         unroll! {
             for i in 0..12 {
-                words[i] ^= self.imask[i];
+                states[i] ^= u32x16::splat(self.imask[i]);
             }
         }
 
-        words_to_le_bytes(&words, &mut self.oblk);
-        self.ooff = offset;
+        statex16_to_bytes(&states, &mut self.oblk);
 
-        rolling::roll_xe(&mut self.omask);
+        self.ooff = offset;
     }
 
     /// Given that N -many message bytes are already absorbed into deck function state and
@@ -209,27 +267,36 @@ impl Xoofff {
         let mut off = 0;
 
         while off < out.len() {
-            let read = cmp::min(BLOCK_SIZE - self.ooff, out.len() - off);
-            out[off..(off + read)].copy_from_slice(&self.oblk[self.ooff..(self.ooff + read)]);
+            let read = cmp::min(PAR_BLOCK_SIZE - self.ooff, out.len() - off);
+            out[off..off + read].copy_from_slice(&self.oblk[self.ooff..self.ooff + read]);
 
             self.ooff += read;
             off += read;
 
-            if self.ooff == BLOCK_SIZE {
-                let mut words = self.omask;
-                xoodoo::permute::<ROUNDS>(&mut words);
+            if self.ooff == PAR_BLOCK_SIZE {
+                let mut omasks = [[0u32; 12]; 16];
+
+                unroll! {
+                    for i in 0..16 {
+                        omasks[i] = self.omask;
+                        rolling::roll_xe(&mut self.omask);
+                    }
+                }
+
+                let mut states = words_to_statex16(&omasks);
+
+                xoodoo::permutex::<16, ROUNDS>(&mut states);
 
                 debug_assert_eq!(LANE_CNT, 12);
                 unroll! {
                     for i in 0..12 {
-                        words[i] ^= self.imask[i];
+                        states[i] ^= u32x16::splat(self.imask[i]);
                     }
                 }
 
-                words_to_le_bytes(&words, &mut self.oblk);
-                self.ooff = 0;
+                statex16_to_bytes(&states, &mut self.oblk);
 
-                rolling::roll_xe(&mut self.omask);
+                self.ooff = 0;
             }
         }
     }
@@ -257,47 +324,55 @@ impl Xoofff {
     }
 }
 
-/// Given a message of length N -bytes ( s.t. N < 48 ), this routine pads the
-/// message following pad10* rule such that padded message length becomes 48 -bytes.
 #[inline(always)]
-pub(crate) fn pad10x(msg: &[u8]) -> [u8; BLOCK_SIZE] {
-    debug_assert!(
-        msg.len() < BLOCK_SIZE,
-        "Paddable message length must be < {}",
-        BLOCK_SIZE
-    );
-
-    let mlen = msg.len();
-    let mut res = [0u8; BLOCK_SIZE];
-
-    res[..mlen].copy_from_slice(msg);
-    res[mlen] = 0x01;
-
-    res
-}
-
-/// Given a byte array of length 48, this routine interprets those bytes as 12 unsigned
-/// 32 -bit integers (= u32) s.t. four consecutive bytes are placed in little endian order
-/// in a u32 word.
-#[inline(always)]
-pub(crate) fn bytes_to_le_words(bytes: &[u8; BLOCK_SIZE]) -> [u32; LANE_CNT] {
-    let mut words = [0u32; LANE_CNT];
+pub fn statex16_to_words(states: &[u32x16; LANE_CNT]) -> [[u32; LANE_CNT]; 16] {
+    let mut words = [[0u32; LANE_CNT]; 16];
 
     debug_assert_eq!(LANE_CNT, 12);
+
     unroll! {
         for i in 0..12 {
-            words[i] = u32::from_le_bytes(bytes[i * 4..(i + 1) * 4].try_into().unwrap());
+            let arr = states[i].to_array();
+            for j in 0..8 {
+                words[j][i] = arr[j];
+            }
         }
     }
+
     words
 }
 
 #[inline(always)]
-pub(crate) fn words_to_le_bytes(words: &[u32; LANE_CNT], bytes: &mut [u8; BLOCK_SIZE]) {
-    debug_assert_eq!(LANE_CNT, 12);
+pub fn statex16_to_bytes(states: &[u32x16; LANE_CNT], out: &mut [u8; PAR_BLOCK_SIZE]) {
+    let words = statex16_to_words(&states);
+
     unroll! {
-        for i in 0..12 {
-            bytes[i * 4..(i + 1) * 4].copy_from_slice(&words[i].to_le_bytes());
+        for i in 0..16 {
+            words_to_le_bytes(
+                &words[i],
+                (&mut out[i * BLOCK_SIZE..(i + 1) * BLOCK_SIZE])
+                    .try_into()
+                    .unwrap(),
+            );
         }
     }
+}
+
+#[inline(always)]
+fn words_to_statex16(words: &[[u32; LANE_CNT]; 16]) -> [u32x16; LANE_CNT] {
+    let mut states = [u32x16::splat(0u32); LANE_CNT];
+
+    debug_assert_eq!(LANE_CNT, 12);
+
+    unroll! {
+        for i in 0..12 {
+            let mut arr = [0u32; 16];
+            for j in 0..8 {
+                arr[j] = words[j][i];
+            }
+            states[i] = u32x16::from_array(arr);
+        }
+    }
+
+    states
 }

--- a/src/simd/x8.rs
+++ b/src/simd/x8.rs
@@ -1,10 +1,16 @@
+use super::xoodoo;
 use crate::rolling;
-use crate::xoodoo;
+use crate::xoodoo as serial_xoodoo;
+use crate::xoofff::{bytes_to_le_words, pad10x, words_to_le_bytes};
+use core::simd::{u32x8, SimdUint};
 use crunchy::unroll;
 use std::cmp;
 
-/// Xoodoo\[n_r\] being a 384 -bit permutation, messages are consumed in 48 -bytes chunks
+/// Xoodoo\[n_r\] being a 384-bit permutation messages are consumed in 48-byte chunks.
 const BLOCK_SIZE: usize = 48;
+
+/// The byte width of the parallel permutation.
+const PAR_BLOCK_SIZE: usize = BLOCK_SIZE * 8;
 
 /// \# -of rounds for Xoodoo permutation, see definition 3 of https://ia.cr/2018/767
 const ROUNDS: usize = 6;
@@ -26,16 +32,17 @@ const LANE_CNT: usize = BLOCK_SIZE / std::mem::size_of::<u32>();
 ///
 /// See https://ia.cr/2016/1188 for definition of Farfalle.
 /// Also see https://ia.cr/2018/767 for definition of Xoofff.
-#[derive(Clone, Copy)]
+///
+#[derive(Clone)]
 pub struct Xoofff {
-    imask: [u32; LANE_CNT], // input mask
-    omask: [u32; LANE_CNT], // output mask
-    acc: [u32; LANE_CNT],   // accumulator
-    iblk: [u8; BLOCK_SIZE], // input message block ( buffer )
-    oblk: [u8; BLOCK_SIZE], // output message block ( buffer )
-    ioff: usize,            // offset into input message block
-    ooff: usize,            // offset into output message block
-    finalized: usize,       // is deck function state finalized ?
+    imask: [u32; LANE_CNT],     // input mask
+    omask: [u32; LANE_CNT],     // output mask
+    acc: [u32x8; LANE_CNT],     // accumulator
+    iblk: [u8; PAR_BLOCK_SIZE], // input message block ( buffer )
+    oblk: [u8; PAR_BLOCK_SIZE], // output message block ( buffer )
+    ioff: usize,                // offset into input message block
+    ooff: usize,                // offset into output message block
+    finalized: usize,           // is deck function state finalized ?
 }
 
 impl Xoofff {
@@ -49,17 +56,16 @@ impl Xoofff {
             BLOCK_SIZE
         );
 
-        // masked key derivation phase
         let padded_key = pad10x(key);
         let mut masked_key = bytes_to_le_words(&padded_key);
-        xoodoo::permute::<ROUNDS>(&mut masked_key);
+        serial_xoodoo::permute::<ROUNDS>(&mut masked_key);
 
         Self {
             imask: masked_key,
             omask: [0u32; LANE_CNT],
-            acc: [0u32; LANE_CNT],
-            iblk: [0u8; BLOCK_SIZE],
-            oblk: [0u8; BLOCK_SIZE],
+            acc: [u32x8::splat(0u32); LANE_CNT],
+            iblk: [0u8; PAR_BLOCK_SIZE],
+            oblk: [0u8; PAR_BLOCK_SIZE],
             ioff: 0,
             ooff: 0,
             finalized: usize::MIN,
@@ -79,32 +85,52 @@ impl Xoofff {
             return;
         }
 
-        let blk_cnt = (self.ioff + msg.len()) / BLOCK_SIZE;
+        let par_blk_cnt = (self.ioff + msg.len()) / PAR_BLOCK_SIZE;
         let mut moff = 0;
 
-        for _ in 0..blk_cnt {
-            let byte_cnt = BLOCK_SIZE - self.ioff;
-
+        for _ in 0..par_blk_cnt {
+            let byte_cnt = PAR_BLOCK_SIZE - self.ioff;
             self.iblk[self.ioff..].copy_from_slice(&msg[moff..(moff + byte_cnt)]);
-            let mut words = bytes_to_le_words(&self.iblk);
 
-            debug_assert_eq!(LANE_CNT, 12);
+            let mut imasks = [[0u32; 12]; 8];
             unroll! {
-                for i in 0..12 {
-                    words[i] ^= self.imask[i];
+                for i in 0..8 {
+                    imasks[i] = self.imask;
+                    rolling::roll_xc(&mut self.imask);
                 }
             }
 
-            xoodoo::permute::<ROUNDS>(&mut words);
+            let imaskx = words_to_statex8(&imasks);
 
-            debug_assert_eq!(LANE_CNT, 12);
+            let mut words = [[0u32; 12]; 8];
             unroll! {
-                for i in 0..12 {
-                    self.acc[i] ^= words[i];
+                for i in 0..8 {
+                    words[i] = bytes_to_le_words(
+                        &self.iblk[i * BLOCK_SIZE..(i + 1) * BLOCK_SIZE]
+                            .try_into()
+                            .unwrap(),
+                    );
                 }
             }
 
-            rolling::roll_xc(&mut self.imask);
+            let mut states = words_to_statex8(&words);
+
+            debug_assert_eq!(LANE_CNT, 12);
+
+            unroll! {
+                for i in 0..12 {
+                    states[i] ^= imaskx[i];
+                }
+            }
+
+            xoodoo::permutex::<8, ROUNDS>(&mut states);
+
+            unroll! {
+                for i in 0..12 {
+                    self.acc[i] ^= states[i];
+                }
+            }
+
             moff += byte_cnt;
             self.ioff = 0;
         }
@@ -146,51 +172,83 @@ impl Xoofff {
         let mask = (1u8 << ds_bit_width) - 1u8;
         let pad_byte = (1u8 << ds_bit_width) | (domain_seperator & mask);
 
+        let blocks = self.ioff / BLOCK_SIZE + 1;
+
         self.iblk[self.ioff..].fill(0);
         self.iblk[self.ioff] = pad_byte;
 
-        let mut words = bytes_to_le_words(&self.iblk);
+        // Absorb the remainder in serial
+        let mut acc_final = [[0u32; 12]; 8];
+        for i in 0..blocks {
+            let mut words = bytes_to_le_words(
+                &self.iblk[i * BLOCK_SIZE..(i + 1) * BLOCK_SIZE]
+                    .try_into()
+                    .unwrap(),
+            );
 
-        debug_assert_eq!(LANE_CNT, 12);
+            debug_assert_eq!(LANE_CNT, 12);
+
+            unroll! {
+                for j in 0..12 {
+                    words[j] ^= self.imask[j];
+                }
+            }
+
+            serial_xoodoo::permute::<ROUNDS>(&mut words);
+
+            unroll! {
+                for j in 0..12 {
+                    acc_final[0][j] ^= words[j];
+                }
+            }
+
+            rolling::roll_xc(&mut self.imask);
+        }
+
+        let accx = words_to_statex8(&acc_final);
+
         unroll! {
             for i in 0..12 {
-                words[i] ^= self.imask[i];
+                self.acc[i] ^= accx[i];
             }
         }
 
-        xoodoo::permute::<ROUNDS>(&mut words);
-
-        debug_assert_eq!(LANE_CNT, 12);
-        unroll! {
-            for i in 0..12 {
-                self.acc[i] ^= words[i];
-            }
-        }
-
-        rolling::roll_xc(&mut self.imask);
         rolling::roll_xc(&mut self.imask);
 
         self.iblk.fill(0);
         self.ioff = 0;
         self.finalized = usize::MAX;
 
-        self.omask.copy_from_slice(&self.acc);
-        xoodoo::permute::<ROUNDS>(&mut self.omask);
+        unroll! {
+            for i in 0..12 {
+                self.omask[i] = self.acc[i].reduce_xor();
+            }
+        }
 
-        let mut words = self.omask;
-        xoodoo::permute::<ROUNDS>(&mut words);
+        serial_xoodoo::permute::<ROUNDS>(&mut self.omask);
+
+        let mut omasks = [[0u32; 12]; 8];
+        unroll! {
+            for i in 0..8 {
+                omasks[i] = self.omask;
+                rolling::roll_xe(&mut self.omask);
+            }
+        }
+
+        let mut states = words_to_statex8(&omasks);
+
+        xoodoo::permutex::<8, ROUNDS>(&mut states);
 
         debug_assert_eq!(LANE_CNT, 12);
         unroll! {
             for i in 0..12 {
-                words[i] ^= self.imask[i];
+                states[i] ^= u32x8::splat(self.imask[i]);
             }
         }
 
-        words_to_le_bytes(&words, &mut self.oblk);
-        self.ooff = offset;
+        statex8_to_bytes(&states, &mut self.oblk);
 
-        rolling::roll_xe(&mut self.omask);
+        self.ooff = offset;
     }
 
     /// Given that N -many message bytes are already absorbed into deck function state and
@@ -209,27 +267,36 @@ impl Xoofff {
         let mut off = 0;
 
         while off < out.len() {
-            let read = cmp::min(BLOCK_SIZE - self.ooff, out.len() - off);
-            out[off..(off + read)].copy_from_slice(&self.oblk[self.ooff..(self.ooff + read)]);
+            let read = cmp::min(PAR_BLOCK_SIZE - self.ooff, out.len() - off);
+            out[off..off + read].copy_from_slice(&self.oblk[self.ooff..self.ooff + read]);
 
             self.ooff += read;
             off += read;
 
-            if self.ooff == BLOCK_SIZE {
-                let mut words = self.omask;
-                xoodoo::permute::<ROUNDS>(&mut words);
+            if self.ooff == PAR_BLOCK_SIZE {
+                let mut omasks = [[0u32; 12]; 8];
+
+                unroll! {
+                    for i in 0..8 {
+                        omasks[i] = self.omask;
+                        rolling::roll_xe(&mut self.omask);
+                    }
+                }
+
+                let mut states = words_to_statex8(&omasks);
+
+                xoodoo::permutex::<8, ROUNDS>(&mut states);
 
                 debug_assert_eq!(LANE_CNT, 12);
                 unroll! {
                     for i in 0..12 {
-                        words[i] ^= self.imask[i];
+                        states[i] ^= u32x8::splat(self.imask[i]);
                     }
                 }
 
-                words_to_le_bytes(&words, &mut self.oblk);
-                self.ooff = 0;
+                statex8_to_bytes(&states, &mut self.oblk);
 
-                rolling::roll_xe(&mut self.omask);
+                self.ooff = 0;
             }
         }
     }
@@ -257,47 +324,55 @@ impl Xoofff {
     }
 }
 
-/// Given a message of length N -bytes ( s.t. N < 48 ), this routine pads the
-/// message following pad10* rule such that padded message length becomes 48 -bytes.
 #[inline(always)]
-pub(crate) fn pad10x(msg: &[u8]) -> [u8; BLOCK_SIZE] {
-    debug_assert!(
-        msg.len() < BLOCK_SIZE,
-        "Paddable message length must be < {}",
-        BLOCK_SIZE
-    );
-
-    let mlen = msg.len();
-    let mut res = [0u8; BLOCK_SIZE];
-
-    res[..mlen].copy_from_slice(msg);
-    res[mlen] = 0x01;
-
-    res
-}
-
-/// Given a byte array of length 48, this routine interprets those bytes as 12 unsigned
-/// 32 -bit integers (= u32) s.t. four consecutive bytes are placed in little endian order
-/// in a u32 word.
-#[inline(always)]
-pub(crate) fn bytes_to_le_words(bytes: &[u8; BLOCK_SIZE]) -> [u32; LANE_CNT] {
-    let mut words = [0u32; LANE_CNT];
+pub fn statex8_to_words(states: &[u32x8; LANE_CNT]) -> [[u32; LANE_CNT]; 8] {
+    let mut words = [[0u32; LANE_CNT]; 8];
 
     debug_assert_eq!(LANE_CNT, 12);
+
     unroll! {
         for i in 0..12 {
-            words[i] = u32::from_le_bytes(bytes[i * 4..(i + 1) * 4].try_into().unwrap());
+            let arr = states[i].to_array();
+            for j in 0..8 {
+                words[j][i] = arr[j];
+            }
         }
     }
+
     words
 }
 
 #[inline(always)]
-pub(crate) fn words_to_le_bytes(words: &[u32; LANE_CNT], bytes: &mut [u8; BLOCK_SIZE]) {
-    debug_assert_eq!(LANE_CNT, 12);
+pub fn statex8_to_bytes(states: &[u32x8; LANE_CNT], out: &mut [u8; PAR_BLOCK_SIZE]) {
+    let words = statex8_to_words(&states);
+
     unroll! {
-        for i in 0..12 {
-            bytes[i * 4..(i + 1) * 4].copy_from_slice(&words[i].to_le_bytes());
+        for i in 0..8 {
+            words_to_le_bytes(
+                &words[i],
+                (&mut out[i * BLOCK_SIZE..(i + 1) * BLOCK_SIZE])
+                    .try_into()
+                    .unwrap(),
+            );
         }
     }
+}
+
+#[inline(always)]
+fn words_to_statex8(words: &[[u32; LANE_CNT]; 8]) -> [u32x8; LANE_CNT] {
+    let mut states = [u32x8::splat(0u32); LANE_CNT];
+
+    debug_assert_eq!(LANE_CNT, 12);
+
+    unroll! {
+        for i in 0..12 {
+            let mut arr = [0u32; 8];
+            for j in 0..8 {
+                arr[j] = words[j][i];
+            }
+            states[i] = u32x8::from_array(arr);
+        }
+    }
+
+    states
 }

--- a/src/simd/xoodoo.rs
+++ b/src/simd/xoodoo.rs
@@ -1,3 +1,4 @@
+use core::simd::{LaneCount, Simd, SupportedLaneCount};
 use crunchy::unroll;
 
 /// Maximum number of rounds one can request to have when applying Xoodoo\[n_r\] permutation i.e. n_r <= MAX_ROUNDS
@@ -11,37 +12,43 @@ const RC: [u32; MAX_ROUNDS] = [
     0x00000380, 0x000000f0, 0x000001a0, 0x00000012,
 ];
 
-/// Given a plane of Xoodoo permutation state ( each plane has 4 lanes, each lane 32 -bit wide ),
-/// this routine function cyclically shifts the plane such that bit at position (x, z) is
-/// moved to (x+T, z+V).
-///
-/// Note, at bit index z = 0, least significant bit of each lane lives.
-/// See row 2 of table 1 of https://ia.cr/2018/767.
 #[inline(always)]
-pub fn cyclic_shift<const T: usize, const V: u32>(plane: &[u32]) -> [u32; 4] {
+pub fn cyclic_shiftx<const N: usize, const T: usize, const V: u32>(
+    plane: &[Simd<u32, N>],
+) -> [Simd<u32, N>; 4]
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         plane.len() == 4,
         "Each lane of Xoodoo permutation state must have four lanes !"
     );
 
-    let mut shifted = [0u32; 4];
+    let shl = Simd::<u32, N>::splat(V);
+    let shr = Simd::<u32, N>::splat(32 - V);
+
+    let mut shifted = [Simd::<u32, N>::splat(0u32); 4];
     unroll! {
         for i in 0..4 {
-            shifted[(T + i) & 3usize] = plane[i].rotate_left(V);
+            shifted[(T + i) & 3usize] = (plane[i] << shl) | (plane[i] >> shr);
         }
     }
+
     shifted
 }
 
 /// θ step mapping of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
-fn theta(state: &mut [u32]) {
+fn thetax<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         state.len() == 12,
         "Xoodoo permutation state must have 12 lanes !"
     );
 
-    let mut p = [0u32; 4];
+    let mut p = [Simd::<u32, N>::splat(0u32); 4];
     unroll! {
         for i in (0..12).step_by(4) {
             p[0] ^= state[i + 0];
@@ -51,10 +58,10 @@ fn theta(state: &mut [u32]) {
         }
     }
 
-    let t0 = cyclic_shift::<1, 5>(&p);
-    let t1 = cyclic_shift::<1, 14>(&p);
+    let t0 = cyclic_shiftx::<N, 1, 5>(&p);
+    let t1 = cyclic_shiftx::<N, 1, 14>(&p);
 
-    let mut e = [0u32; 4];
+    let mut e = [Simd::<u32, N>::splat(0u32); 4];
     unroll! {
         for i in 0..4 {
             e[i] = t0[i] ^ t1[i];
@@ -73,14 +80,17 @@ fn theta(state: &mut [u32]) {
 
 /// ρ_west step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
-fn rho_west(state: &mut [u32]) {
+fn rho_westx<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         state.len() == 12,
         "Xoodoo permutation state must have 12 lanes !"
     );
 
-    let t0 = cyclic_shift::<1, 0>(&state[4..8]);
-    let t1 = cyclic_shift::<0, 11>(&state[8..12]);
+    let t0 = cyclic_shiftx::<N, 1, 0>(&state[4..8]);
+    let t1 = cyclic_shiftx::<N, 0, 11>(&state[8..12]);
 
     state[4..8].copy_from_slice(&t0);
     state[8..12].copy_from_slice(&t1);
@@ -88,14 +98,17 @@ fn rho_west(state: &mut [u32]) {
 
 /// ρ_east step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
-fn rho_east(state: &mut [u32]) {
+fn rho_eastx<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         state.len() == 12,
         "Xoodoo permutation state must have 12 lanes !"
     );
 
-    let t0 = cyclic_shift::<0, 1>(&state[4..8]);
-    let t1 = cyclic_shift::<2, 8>(&state[8..12]);
+    let t0 = cyclic_shiftx::<N, 0, 1>(&state[4..8]);
+    let t1 = cyclic_shiftx::<N, 2, 8>(&state[8..12]);
 
     state[4..8].copy_from_slice(&t0);
     state[8..12].copy_from_slice(&t1);
@@ -103,38 +116,44 @@ fn rho_east(state: &mut [u32]) {
 
 /// ι step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
-fn iota(state: &mut [u32], ridx: usize) {
+fn iotax<const N: usize>(state: &mut [Simd<u32, N>], ridx: usize)
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         state.len() == 12,
         "Xoodoo permutation state must have 12 lanes !"
     );
 
-    state[0] ^= RC[ridx]
+    state[0] ^= Simd::<u32, N>::splat(RC[ridx]);
 }
 
 /// χ step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
-fn chi(state: &mut [u32]) {
+fn chix<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         state.len() == 12,
         "Xoodoo permutation state must have 12 lanes !"
     );
 
-    let mut b0 = [0u32; 4];
+    let mut b0 = [Simd::<u32, N>::splat(0u32); 4];
     unroll! {
         for i in 0..4 {
             b0[i] = !state[4 + i] & state[8 + i];
         }
     }
 
-    let mut b1 = [0u32; 4];
+    let mut b1 = [Simd::<u32, N>::splat(0u32); 4];
     unroll! {
         for i in 0..4 {
             b1[i] = !state[8 + i] & state[i];
         }
     }
 
-    let mut b2 = [0u32; 4];
+    let mut b2 = [Simd::<u32, N>::splat(0u32); 4];
     unroll! {
         for i in 0..4 {
             b2[i] = !state[i] & state[4 + i];
@@ -152,24 +171,30 @@ fn chi(state: &mut [u32]) {
 
 /// Round function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
-fn round(state: &mut [u32], ridx: usize) {
+fn roundx<const N: usize>(state: &mut [Simd<u32, N>], ridx: usize)
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         state.len() == 12,
         "Xoodoo permutation state must have 12 lanes !"
     );
     debug_assert!(ridx < MAX_ROUNDS, "Round index must ∈ [0, MAX_ROUNDS) !");
 
-    theta(state);
-    rho_west(state);
-    iota(state, ridx);
-    chi(state);
-    rho_east(state);
+    thetax(state);
+    rho_westx(state);
+    iotax(state, ridx);
+    chix(state);
+    rho_eastx(state);
 }
 
 /// Xoodoo\[n_r\] permutation function s.t. n_r ( <= MAX_ROUNDS ) times round function
 /// is applied on permutation state, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
-pub fn permute<const ROUNDS: usize>(state: &mut [u32]) {
+pub fn permutex<const N: usize, const ROUNDS: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
     debug_assert!(
         state.len() == 12,
         "Xoodoo permutation state must have 12 lanes !"
@@ -181,6 +206,45 @@ pub fn permute<const ROUNDS: usize>(state: &mut [u32]) {
 
     let start = MAX_ROUNDS - ROUNDS;
     for ridx in start..MAX_ROUNDS {
-        round(state, ridx);
+        roundx(state, ridx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_xoodoo_simd() {
+        use crate::simd::xoodoo::permutex;
+        use crate::xoodoo::permute;
+        use core::simd::u32x2;
+        use rand::{thread_rng, Rng};
+
+        let mut rng = thread_rng();
+
+        let mut state1 = [0u32; 12];
+        let mut state2 = [0u32; 12];
+
+        rng.fill(&mut state1);
+        rng.fill(&mut state2);
+
+        let mut statex2 = [u32x2::splat(0u32); 12];
+        for i in 0..12 {
+            statex2[i] = u32x2::from_slice(&[state1[i], state2[i]]);
+        }
+
+        permute::<12>(&mut state1);
+        permute::<12>(&mut state2);
+        permutex::<2, 12>(&mut statex2);
+
+        let mut state12 = [0u32; 12];
+        let mut state22 = [0u32; 12];
+        for i in 0..12 {
+            let [s1, s2] = statex2[i].to_array();
+            state12[i] = s1;
+            state22[i] = s2;
+        }
+
+        assert_eq!(state1, state12);
+        assert_eq!(state2, state22);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,51 +14,46 @@ fn test_xoofff_kat() {
     let file = File::open(kat_file).unwrap();
     let mut reader = BufReader::new(file).lines();
 
-    loop {
-        if let Some(line) = reader.next() {
-            // key to be used for instantiating deck function
-            let key = line.unwrap();
-            let key = key.split(" ").collect::<Vec<_>>()[1];
-            let key = hex::decode(key).unwrap();
+    while let Some(line) = reader.next() {
+        // key to be used for instantiating deck function
+        let key = line.unwrap();
+        let key = key.split(" ").collect::<Vec<_>>()[1];
+        let key = hex::decode(key).unwrap();
 
-            // message to be absorbed into deck function
-            let msg = reader.next().unwrap().unwrap();
-            let msg = msg.split(" ").collect::<Vec<_>>()[1];
-            let msg = hex::decode(msg).unwrap();
+        // message to be absorbed into deck function
+        let msg = reader.next().unwrap().unwrap();
+        let msg = msg.split(" ").collect::<Vec<_>>()[1];
+        let msg = hex::decode(msg).unwrap();
 
-            // # -of bytes to be skipped before message squeezing begins
-            let q = reader.next().unwrap().unwrap();
-            let q = q.split(" ").collect::<Vec<_>>()[1]
-                .parse::<usize>()
-                .unwrap();
+        // # -of bytes to be skipped before message squeezing begins
+        let q = reader.next().unwrap().unwrap();
+        let q = q.split(" ").collect::<Vec<_>>()[1]
+            .parse::<usize>()
+            .unwrap();
 
-            let out = reader.next().unwrap().unwrap();
-            let out = out.split(" ").collect::<Vec<_>>()[1];
+        let out = reader.next().unwrap().unwrap();
+        let out = out.split(" ").collect::<Vec<_>>()[1];
 
-            // expected squeezed bytes
-            let expected = hex::decode(out).unwrap();
-            // to be squeezed bytes
-            let mut computed = vec![0u8; expected.len()];
+        // expected squeezed bytes
+        let expected = hex::decode(out).unwrap();
+        // to be squeezed bytes
+        let mut computed = vec![0u8; expected.len()];
 
-            let mut deck = Xoofff::new(&key);
-            deck.absorb(&msg);
-            deck.finalize(0, 0, q);
-            deck.squeeze(&mut computed);
+        let mut deck = Xoofff::new(&key);
+        deck.absorb(&msg);
+        deck.finalize(0, 0, q);
+        deck.squeeze(&mut computed);
 
-            assert_eq!(
-                expected,
-                computed,
-                "key = {}, msg = {}, q = {}",
-                hex::encode(&key),
-                hex::encode(&msg),
-                q
-            );
+        assert_eq!(
+            expected,
+            computed,
+            "key = {}, msg = {}, q = {}",
+            hex::encode(&key),
+            hex::encode(&msg),
+            q
+        );
 
-            reader.next().unwrap().unwrap(); // skip the empty line
-        } else {
-            // no more test vectors, time to break out of loop
-            break;
-        }
+        reader.next().unwrap().unwrap(); // skip the empty line
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -121,39 +121,3 @@ fn test_xoofff_incremental_io(
 
     assert_eq!(dig0, dig1);
 }
-
-#[cfg(feature = "simd")]
-#[test]
-fn test_xoodoo_simd() {
-    use crate::xoodoo::{permute, permutex};
-    use core::simd::u32x2;
-    use rand::Rng;
-
-    let mut rng = thread_rng();
-
-    let mut state1 = [0u32; 12];
-    let mut state2 = [0u32; 12];
-
-    rng.fill(&mut state1);
-    rng.fill(&mut state2);
-
-    let mut statex2 = [u32x2::splat(0u32); 12];
-    for i in 0..12 {
-        statex2[i] = u32x2::from_slice(&[state1[i], state2[i]]);
-    }
-
-    permute::<12>(&mut state1);
-    permute::<12>(&mut state2);
-    permutex::<2, 12>(&mut statex2);
-
-    let mut state12 = [0u32; 12];
-    let mut state22 = [0u32; 12];
-    for i in 0..12 {
-        let [s1, s2] = statex2[i].to_array();
-        state12[i] = s1;
-        state22[i] = s2;
-    }
-
-    assert_eq!(state1, state12);
-    assert_eq!(state2, state22);
-}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -126,3 +126,39 @@ fn test_xoofff_incremental_io(
 
     assert_eq!(dig0, dig1);
 }
+
+#[cfg(feature = "simd")]
+#[test]
+fn test_xoodoo_simd() {
+    use crate::xoodoo::{permute, permutex};
+    use core::simd::u32x2;
+    use rand::Rng;
+
+    let mut rng = thread_rng();
+
+    let mut state1 = [0u32; 12];
+    let mut state2 = [0u32; 12];
+
+    rng.fill(&mut state1);
+    rng.fill(&mut state2);
+
+    let mut statex2 = [u32x2::splat(0u32); 12];
+    for i in 0..12 {
+        statex2[i] = u32x2::from_slice(&[state1[i], state2[i]]);
+    }
+
+    permute::<12>(&mut state1);
+    permute::<12>(&mut state2);
+    permutex::<2, 12>(&mut statex2);
+
+    let mut state12 = [0u32; 12];
+    let mut state22 = [0u32; 12];
+    for i in 0..12 {
+        let [s1, s2] = statex2[i].to_array();
+        state12[i] = s1;
+        state22[i] = s2;
+    }
+
+    assert_eq!(state1, state12);
+    assert_eq!(state2, state22);
+}

--- a/src/xoodoo.rs
+++ b/src/xoodoo.rs
@@ -1,5 +1,8 @@
 use crunchy::unroll;
 
+#[cfg(feature = "simd")]
+use core::simd::{LaneCount, Simd, SupportedLaneCount};
+
 /// Maximum number of rounds one can request to have when applying Xoodoo\[n_r\] permutation i.e. n_r <= MAX_ROUNDS
 ///
 /// See table 2 of https://ia.cr/2018/767
@@ -30,6 +33,32 @@ pub fn cyclic_shift<const T: usize, const V: u32>(plane: &[u32]) -> [u32; 4] {
             shifted[(T + i) & 3usize] = plane[i].rotate_left(V);
         }
     }
+    shifted
+}
+
+#[cfg(feature = "simd")]
+#[inline(always)]
+pub fn cyclic_shiftx<const N: usize, const T: usize, const V: u32>(
+    plane: &[Simd<u32, N>],
+) -> [Simd<u32, N>; 4]
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        plane.len() == 4,
+        "Each lane of Xoodoo permutation state must have four lanes !"
+    );
+
+    let shl = Simd::<u32, N>::splat(V);
+    let shr = Simd::<u32, N>::splat(32 - V);
+
+    let mut shifted = [Simd::<u32, N>::splat(0u32); 4];
+    unroll! {
+        for i in 0..4 {
+            shifted[(T + i) & 3usize] = (plane[i] << shl) | (plane[i] >> shr);
+        }
+    }
+
     shifted
 }
 
@@ -71,6 +100,48 @@ fn theta(state: &mut [u32]) {
     }
 }
 
+/// θ step mapping of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn thetax<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let mut p = [Simd::<u32, N>::splat(0u32); 4];
+    unroll! {
+        for i in (0..12).step_by(4) {
+            p[0] ^= state[i + 0];
+            p[1] ^= state[i + 1];
+            p[2] ^= state[i + 2];
+            p[3] ^= state[i + 3];
+        }
+    }
+
+    let t0 = cyclic_shiftx::<N, 1, 5>(&p);
+    let t1 = cyclic_shiftx::<N, 1, 14>(&p);
+
+    let mut e = [Simd::<u32, N>::splat(0u32); 4];
+    unroll! {
+        for i in 0..4 {
+            e[i] = t0[i] ^ t1[i];
+        }
+    }
+
+    unroll! {
+        for i in (0..12).step_by(4) {
+            state[i + 0] ^= e[0];
+            state[i + 1] ^= e[1];
+            state[i + 2] ^= e[2];
+            state[i + 3] ^= e[3];
+        }
+    }
+}
+
 /// ρ_west step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
 fn rho_west(state: &mut [u32]) {
@@ -81,6 +152,25 @@ fn rho_west(state: &mut [u32]) {
 
     let t0 = cyclic_shift::<1, 0>(&state[4..8]);
     let t1 = cyclic_shift::<0, 11>(&state[8..12]);
+
+    state[4..8].copy_from_slice(&t0);
+    state[8..12].copy_from_slice(&t1);
+}
+
+/// ρ_west step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn rho_westx<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let t0 = cyclic_shiftx::<N, 1, 0>(&state[4..8]);
+    let t1 = cyclic_shiftx::<N, 0, 11>(&state[8..12]);
 
     state[4..8].copy_from_slice(&t0);
     state[8..12].copy_from_slice(&t1);
@@ -101,6 +191,25 @@ fn rho_east(state: &mut [u32]) {
     state[8..12].copy_from_slice(&t1);
 }
 
+/// ρ_east step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn rho_eastx<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let t0 = cyclic_shiftx::<N, 0, 1>(&state[4..8]);
+    let t1 = cyclic_shiftx::<N, 2, 8>(&state[8..12]);
+
+    state[4..8].copy_from_slice(&t0);
+    state[8..12].copy_from_slice(&t1);
+}
+
 /// ι step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
 fn iota(state: &mut [u32], ridx: usize) {
@@ -110,6 +219,19 @@ fn iota(state: &mut [u32], ridx: usize) {
     );
 
     state[0] ^= RC[ridx]
+}
+
+#[cfg(feature = "simd")]
+fn iotax<const N: usize>(state: &mut [Simd<u32, N>], ridx: usize)
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    state[0] ^= Simd::<u32, N>::splat(RC[ridx]);
 }
 
 /// χ step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
@@ -150,6 +272,48 @@ fn chi(state: &mut [u32]) {
     }
 }
 
+/// χ step mapping function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn chix<const N: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+
+    let mut b0 = [Simd::<u32, N>::splat(0u32); 4];
+    unroll! {
+        for i in 0..4 {
+            b0[i] = !state[4 + i] & state[8 + i];
+        }
+    }
+
+    let mut b1 = [Simd::<u32, N>::splat(0u32); 4];
+    unroll! {
+        for i in 0..4 {
+            b1[i] = !state[8 + i] & state[i];
+        }
+    }
+
+    let mut b2 = [Simd::<u32, N>::splat(0u32); 4];
+    unroll! {
+        for i in 0..4 {
+            b2[i] = !state[i] & state[4 + i];
+        }
+    }
+
+    unroll! {
+        for i in 0..4 {
+            state[i] ^= b0[i];
+            state[4 + i] ^= b1[i];
+            state[8 + i] ^= b2[i];
+        }
+    }
+}
+
 /// Round function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
 #[inline(always)]
 fn round(state: &mut [u32], ridx: usize) {
@@ -164,6 +328,26 @@ fn round(state: &mut [u32], ridx: usize) {
     iota(state, ridx);
     chi(state);
     rho_east(state);
+}
+
+/// Round function of Xoodoo permutation, as described in algorithm 1 of https://ia.cr/2018/767.
+#[cfg(feature = "simd")]
+#[inline(always)]
+fn roundx<const N: usize>(state: &mut [Simd<u32, N>], ridx: usize)
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+    debug_assert!(ridx < MAX_ROUNDS, "Round index must ∈ [0, MAX_ROUNDS) !");
+
+    thetax(state);
+    rho_westx(state);
+    iotax(state, ridx);
+    chix(state);
+    rho_eastx(state);
 }
 
 /// Xoodoo\[n_r\] permutation function s.t. n_r ( <= MAX_ROUNDS ) times round function
@@ -182,5 +366,28 @@ pub fn permute<const ROUNDS: usize>(state: &mut [u32]) {
     let start = MAX_ROUNDS - ROUNDS;
     for ridx in start..MAX_ROUNDS {
         round(state, ridx);
+    }
+}
+
+/// Xoodoo\[n_r\] permutation function s.t. n_r ( <= MAX_ROUNDS ) times round function
+/// is applied on permutation state, as described in algorithm 1 of https://ia.cr/2018/767.
+#[cfg(feature = "simd")]
+#[inline(always)]
+pub fn permutex<const N: usize, const ROUNDS: usize>(state: &mut [Simd<u32, N>])
+where
+    LaneCount<N>: SupportedLaneCount,
+{
+    debug_assert!(
+        state.len() == 12,
+        "Xoodoo permutation state must have 12 lanes !"
+    );
+    debug_assert!(
+        ROUNDS <= MAX_ROUNDS,
+        "Requested rounds must be < MAX_ROUNDS !"
+    );
+
+    let start = MAX_ROUNDS - ROUNDS;
+    for ridx in start..MAX_ROUNDS {
+        roundx(state, ridx);
     }
 }


### PR DESCRIPTION
- SIMD enabled by `simd` feature, make sure to compile using nightly (`cargo +nightly`) for a supported target (using `RUSTFLAGS='-C target-cpu=native'` or `RUSTFLAGS='-C target_feature=+avx2'` for example).
- Checks at compile time if the target supports AVX512/AVX2/WASM SIMD and chooses x16/x8/x4 accordingly.
- Keeps bigger in and out buffers in the SIMD implementation, so only useful  if atleast 48 * 16/8/4 byte input/outputs are absorbed/squeezed.
- SIMD xoodoo permutation is fully generic over the amount of SIMD  lanes.
- Xoofff implementations are not fully generic due to unrolling on a  generic constant not being possible using crunchy.
- Operations converting bytes to N parallel state and vice versa are not optimized.  They might be faster using gather/scatter methods.

TODO:
- [ ] document how to enable the feature.
- [ ] doc test compilation currently fails.
- [ ] test simd in CI.
- [ ] test or not include the x16 code (support is low, I don't have it either)