### PR TITLE
Benchmark with `criterion-cycles-per-byte`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,3 +18,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run tests
       run: cargo test --lib
+    - name: Run examples
+      run: cargo run --example deck_function

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xoofff"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Anjan Roy <hello@itzmeanjan.in>"]
 description = "Farfalle with Xoodoo: Parallel Permutation-based Cryptography"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ crunchy = "=0.2.2"
 [dev-dependencies]
 rand = "=0.8.5"
 test-case = "=3.3.1"
+criterion = "=0.5.1"
 hex = "=0.4.3"
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64", target_arch = "loongarch64"))'.dev-dependencies]
+criterion-cycles-per-byte = {git = "https://github.com/itzmeanjan/criterion-cycles-per-byte", rev = "63edc6b46"}
 
 [features]
 dev = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ crunchy = "=0.2.2"
 
 [dev-dependencies]
 rand = "=0.8.5"
-test-case = "=3.1.0"
-criterion = "=0.4.0"
+test-case = "=3.3.1"
 hex = "=0.4.3"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ Rust stable toolchain, which you can obtain by following https://rustup.rs.
 ```bash
 # When developing this library, I was using
 rustc --version
-rustc 1.68.2 (9eb3afe9e 2023-03-27)
+rustc 1.74.0 (79e9716c9 2023-11-13)
 ```
+
+> [!TIP]
+> I advise you to also use `cargo-criterion` for running benchmark executable. Read more about it @ https://crates.io/crates/cargo-criterion. You can install it system-wide by issuing `$ cargo install cargo-criterion`.
 
 ## Testing
 
@@ -26,7 +29,8 @@ For ensuring that Xoofff deck function is correctly implemented and both
 
 reach same state, I maintain few test cases. You can run those by issuing
 
-> **Note** For ensuring functional correctness of Xoofff implementation, I use known answer tests, generated using reference implementation by Keccak team, following instructions specified on https://gist.github.com/itzmeanjan/504113021dec30a0909e5f5b47a5bde5.
+> [!NOTE]
+> For ensuring functional correctness of Xoofff implementation, I use known answer tests, generated using reference implementation by Xoofff authors, following instructions specified on https://gist.github.com/itzmeanjan/504113021dec30a0909e5f5b47a5bde5.
 
 ```bash
 cargo test --lib
@@ -36,154 +40,133 @@ cargo test --lib
 
 Issue following command for benchmarking deck function Xoofff for various input sizes.
 
+> [!CAUTION]
+> When benchmarking make sure you've disabled CPU frequency scaling, otherwise numbers you see can be pretty misleading. I found https://github.com/google/benchmark/blob/b40db869/docs/reducing_variance.md helpful.
+
 ```bash
-RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench xoofff
+RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo criterion xoofff
 ```
 
 If interested in benchmarking underlying Xoodoo permutation, consider issuing following command.
 
 ```bash
-RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench xoodoo --features="dev"
+RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo criterion xoodoo --features="dev"
 ```
 
-### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
+> [!NOTE]
+> In case you're running benchmarks on `aarch64` target, consider reading https://github.com/itzmeanjan/criterion-cycles-per-byte/blob/63edc6b46/src/lib.rs#L63-L70.
 
-#### Xoodoo[{6, 12}] Permutation
+> [!IMPORTANT]
+> In case you didn't install `cargo-criterion`, you've to build and execute benchmark binary with `$ RUSTFLAGS="-C opt-level=3 -C target-cpu=native" cargo bench ...`.
 
-```bash
-xoodoo/xoodoo[6] (cached)
-                        time:   [30.989 ns 31.113 ns 31.274 ns]
-                        thrpt:  [1.4294 GiB/s 1.4368 GiB/s 1.4426 GiB/s]
-Found 9 outliers among 100 measurements (9.00%)
-  3 (3.00%) high mild
-  6 (6.00%) high severe
-xoodoo/xoodoo[6] (random)
-                        time:   [34.302 ns 34.748 ns 35.229 ns]
-                        thrpt:  [1.2689 GiB/s 1.2865 GiB/s 1.3032 GiB/s]
-Found 4 outliers among 100 measurements (4.00%)
-  3 (3.00%) high mild
-  1 (1.00%) high severe
-
-xoodoo/xoodoo[12] (cached)
-                        time:   [60.590 ns 60.857 ns 61.209 ns]
-                        thrpt:  [747.86 MiB/s 752.19 MiB/s 755.50 MiB/s]
-Found 10 outliers among 100 measurements (10.00%)
-  5 (5.00%) high mild
-  5 (5.00%) high severe
-xoodoo/xoodoo[12] (random)
-                        time:   [63.608 ns 64.406 ns 65.271 ns]
-                        thrpt:  [701.33 MiB/s 710.75 MiB/s 719.66 MiB/s]
-Found 8 outliers among 100 measurements (8.00%)
-  7 (7.00%) high mild
-  1 (1.00%) high severe
-```
+### On 12th Gen Intel(R) Core(TM) i7-1260P
 
 #### Xoofff - Deck Function
 
 ```bash
-xoofff/key = 32 | in = 32 | out = 32 | offset = 16 (cached)
-                        time:   [258.24 ns 259.25 ns 260.52 ns]
-                        thrpt:  [292.86 MiB/s 294.29 MiB/s 295.43 MiB/s]
-Found 7 outliers among 100 measurements (7.00%)
-  3 (3.00%) high mild
-  4 (4.00%) high severe
-xoofff/key = 32 | in = 32 | out = 32 | offset = 16 (random)
-                        time:   [321.99 ns 325.93 ns 330.51 ns]
-                        thrpt:  [230.84 MiB/s 234.08 MiB/s 236.94 MiB/s]
-Found 15 outliers among 100 measurements (15.00%)
-  9 (9.00%) high mild
-  6 (6.00%) high severe
+xoofff/key = 32B | in = 32B | out = 32B | offset = 16B (cached)                                                                            
+                        time:   [386.0719 cycles 386.7368 cycles 388.0084 cycles]
+                        thrpt:  [4.8501 cpb 4.8342 cpb 4.8259 cpb]
+xoofff/key = 32B | in = 32B | out = 32B | offset = 16B (random)                                                                            
+                        time:   [463.2273 cycles 468.2415 cycles 472.7826 cycles]
+                        thrpt:  [5.9098 cpb 5.8530 cpb 5.7903 cpb]
 
-xoofff/key = 32 | in = 64 | out = 32 | offset = 16 (cached)
-                        time:   [295.70 ns 296.21 ns 296.77 ns]
-                        thrpt:  [359.91 MiB/s 360.59 MiB/s 361.21 MiB/s]
-Found 7 outliers among 100 measurements (7.00%)
-  3 (3.00%) high mild
-  4 (4.00%) high severe
-xoofff/key = 32 | in = 64 | out = 32 | offset = 16 (random)
-                        time:   [362.85 ns 365.61 ns 368.72 ns]
-                        thrpt:  [289.68 MiB/s 292.14 MiB/s 294.36 MiB/s]
-Found 12 outliers among 100 measurements (12.00%)
-  4 (4.00%) high mild
-  8 (8.00%) high severe
+xoofff/key = 32B | in = 128B | out = 32B | offset = 16B (cached)                                                                            
+                        time:   [510.5196 cycles 510.6597 cycles 510.8342 cycles]
+                        thrpt:  [2.9025 cpb 2.9015 cpb 2.9007 cpb]
+xoofff/key = 32B | in = 128B | out = 32B | offset = 16B (random)                                                                            
+                        time:   [597.6074 cycles 598.6353 cycles 599.5923 cycles]
+                        thrpt:  [3.4068 cpb 3.4013 cpb 3.3955 cpb]
 
-xoofff/key = 32 | in = 128 | out = 32 | offset = 16 (cached)
-                        time:   [331.04 ns 331.81 ns 332.67 ns]
-                        thrpt:  [504.55 MiB/s 505.85 MiB/s 507.03 MiB/s]
-Found 6 outliers among 100 measurements (6.00%)
-  3 (3.00%) high mild
-  3 (3.00%) high severe
-xoofff/key = 32 | in = 128 | out = 32 | offset = 16 (random)
-                        time:   [413.78 ns 418.28 ns 423.30 ns]
-                        thrpt:  [396.52 MiB/s 401.28 MiB/s 405.64 MiB/s]
-Found 11 outliers among 100 measurements (11.00%)
-  1 (1.00%) low mild
-  7 (7.00%) high mild
-  3 (3.00%) high severe
+xoofff/key = 32B | in = 512B | out = 32B | offset = 16B (cached)                                                                            
+                        time:   [993.0588 cycles 994.1031 cycles 995.7628 cycles]
+                        thrpt:  [1.7781 cpb 1.7752 cpb 1.7733 cpb]
+xoofff/key = 32B | in = 512B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [1136.8571 cycles 1139.8106 cycles 1143.5883 cycles]
+                        thrpt:  [2.0421 cpb 2.0354 cpb 2.0301 cpb]
 
-xoofff/key = 32 | in = 256 | out = 32 | offset = 16 (cached)
-                        time:   [437.37 ns 438.47 ns 439.69 ns]
-                        thrpt:  [659.36 MiB/s 661.21 MiB/s 662.86 MiB/s]
-Found 6 outliers among 100 measurements (6.00%)
-  4 (4.00%) high mild
-  2 (2.00%) high severe
-xoofff/key = 32 | in = 256 | out = 32 | offset = 16 (random)
-                        time:   [549.86 ns 555.27 ns 560.91 ns]
-                        thrpt:  [516.87 MiB/s 522.12 MiB/s 527.25 MiB/s]
-Found 8 outliers among 100 measurements (8.00%)
-  6 (6.00%) high mild
-  2 (2.00%) high severe
+xoofff/key = 32B | in = 2048B | out = 32B | offset = 16B (cached)                                                                             
+                        time:   [2924.0033 cycles 2931.8707 cycles 2941.8708 cycles]
+                        thrpt:  [1.4036 cpb 1.3988 cpb 1.3950 cpb]
+xoofff/key = 32B | in = 2048B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [3010.5796 cycles 3014.4697 cycles 3018.8273 cycles]
+                        thrpt:  [1.4403 cpb 1.4382 cpb 1.4363 cpb]
 
-xoofff/key = 32 | in = 512 | out = 32 | offset = 16 (cached)
-                        time:   [614.95 ns 616.40 ns 617.97 ns]
-                        thrpt:  [864.21 MiB/s 866.41 MiB/s 868.46 MiB/s]
-Found 7 outliers among 100 measurements (7.00%)
-  6 (6.00%) high mild
-  1 (1.00%) high severe
-xoofff/key = 32 | in = 512 | out = 32 | offset = 16 (random)
-                        time:   [806.63 ns 819.31 ns 831.76 ns]
-                        thrpt:  [642.08 MiB/s 651.83 MiB/s 662.09 MiB/s]
-Found 1 outliers among 100 measurements (1.00%)
-  1 (1.00%) high mild
+xoofff/key = 32B | in = 8192B | out = 32B | offset = 16B (cached)                                                                             
+                        time:   [10624.0893 cycles 10626.9955 cycles 10630.3327 cycles]
+                        thrpt:  [1.2901 cpb 1.2897 cpb 1.2893 cpb]
+xoofff/key = 32B | in = 8192B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [10801.9904 cycles 10817.4401 cycles 10835.1726 cycles]
+                        thrpt:  [1.3149 cpb 1.3128 cpb 1.3109 cpb]
+```
 
-xoofff/key = 32 | in = 1024 | out = 32 | offset = 16 (cached)
-                        time:   [1.0031 µs 1.0050 µs 1.0071 µs]
-                        thrpt:  [1015.1 MiB/s 1017.2 MiB/s 1019.2 MiB/s]
-Found 4 outliers among 100 measurements (4.00%)
-  2 (2.00%) high mild
-  2 (2.00%) high severe
-xoofff/key = 32 | in = 1024 | out = 32 | offset = 16 (random)
-                        time:   [1.1083 µs 1.1182 µs 1.1297 µs]
-                        thrpt:  [904.96 MiB/s 914.30 MiB/s 922.46 MiB/s]
-Found 9 outliers among 100 measurements (9.00%)
-  3 (3.00%) high mild
-  6 (6.00%) high severe
+#### Xoodoo[{6, 12}] Permutation
 
-xoofff/key = 32 | in = 2048 | out = 32 | offset = 16 (cached)
-                        time:   [1.7482 µs 1.7524 µs 1.7570 µs]
-                        thrpt:  [1.1110 GiB/s 1.1139 GiB/s 1.1166 GiB/s]
-Found 7 outliers among 100 measurements (7.00%)
-  5 (5.00%) high mild
-  2 (2.00%) high severe
-xoofff/key = 32 | in = 2048 | out = 32 | offset = 16 (random)
-                        time:   [1.8832 µs 1.8998 µs 1.9186 µs]
-                        thrpt:  [1.0175 GiB/s 1.0275 GiB/s 1.0365 GiB/s]
-Found 14 outliers among 100 measurements (14.00%)
-  7 (7.00%) high mild
-  7 (7.00%) high severe
+```bash
+xoodoo/6 (cached)       time:   [71.5661 cycles 71.7006 cycles 71.9454 cycles]                
+                        thrpt:  [1.4989 cpb 1.4938 cpb 1.4910 cpb]
+xoodoo/6 (random)       time:   [82.5140 cycles 82.5797 cycles 82.6480 cycles]                
+                        thrpt:  [1.7218 cpb 1.7204 cpb 1.7190 cpb]
 
-xoofff/key = 32 | in = 4096 | out = 32 | offset = 16 (cached)
-                        time:   [3.2770 µs 3.2899 µs 3.3051 µs]
-                        thrpt:  [1.1677 GiB/s 1.1731 GiB/s 1.1777 GiB/s]
-Found 9 outliers among 100 measurements (9.00%)
-  6 (6.00%) high mild
-  3 (3.00%) high severe
-xoofff/key = 32 | in = 4096 | out = 32 | offset = 16 (random)
-                        time:   [3.4298 µs 3.4573 µs 3.4888 µs]
-                        thrpt:  [1.1062 GiB/s 1.1163 GiB/s 1.1253 GiB/s]
-Found 12 outliers among 100 measurements (12.00%)
-  3 (3.00%) high mild
-  9 (9.00%) high severe
+xoodoo/12 (cached)      time:   [138.7907 cycles 138.8587 cycles 138.9365 cycles]             
+                        thrpt:  [2.8945 cpb 2.8929 cpb 2.8915 cpb]
+xoodoo/12 (random)      time:   [150.6641 cycles 152.5450 cycles 154.7112 cycles]             
+                        thrpt:  [3.2231 cpb 3.1780 cpb 3.1388 cpb]
+```
+
+### On ARM Cortex-A72 (i.e. Raspberry Pi 4B)
+
+#### Xoofff - Deck Function
+
+```bash
+xoofff/key = 32B | in = 32B | out = 32B | offset = 16B (cached)                                                                             
+                        time:   [1475.7031 cycles 1475.7816 cycles 1475.8610 cycles]
+                        thrpt:  [18.4483 cpb 18.4473 cpb 18.4463 cpb]
+xoofff/key = 32B | in = 32B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [1614.8130 cycles 1617.2083 cycles 1619.2197 cycles]
+                        thrpt:  [20.2402 cpb 20.2151 cpb 20.1852 cpb]
+
+xoofff/key = 32B | in = 128B | out = 32B | offset = 16B (cached)                                                                             
+                        time:   [2155.4275 cycles 2155.6064 cycles 2155.8013 cycles]
+                        thrpt:  [12.2489 cpb 12.2478 cpb 12.2467 cpb]
+xoofff/key = 32B | in = 128B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [2358.8773 cycles 2366.7201 cycles 2373.2365 cycles]
+                        thrpt:  [13.4843 cpb 13.4473 cpb 13.4027 cpb]
+
+xoofff/key = 32B | in = 512B | out = 32B | offset = 16B (cached)                                                                             
+                        time:   [4846.7515 cycles 4847.1301 cycles 4847.5460 cycles]
+                        thrpt:  [8.6563 cpb 8.6556 cpb 8.6549 cpb]
+xoofff/key = 32B | in = 512B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [5129.3271 cycles 5141.8396 cycles 5152.6335 cycles]
+                        thrpt:  [9.2011 cpb 9.1819 cpb 9.1595 cpb]
+
+xoofff/key = 32B | in = 2048B | out = 32B | offset = 16B (cached)                                                                             
+                        time:   [15637.2770 cycles 15638.4849 cycles 15639.8726 cycles]
+                        thrpt:  [7.4618 cpb 7.4611 cpb 7.4605 cpb]
+xoofff/key = 32B | in = 2048B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [16086.6226 cycles 16098.8318 cycles 16109.5064 cycles]
+                        thrpt:  [7.6858 cpb 7.6807 cpb 7.6749 cpb]
+
+xoofff/key = 32B | in = 8192B | out = 32B | offset = 16B (cached)                                                                             
+                        time:   [58704.8839 cycles 58707.4874 cycles 58710.3427 cycles]
+                        thrpt:  [7.1250 cpb 7.1247 cpb 7.1244 cpb]
+xoofff/key = 32B | in = 8192B | out = 32B | offset = 16B (random)                                                                             
+                        time:   [59828.4330 cycles 59853.6571 cycles 59876.0584 cycles]
+                        thrpt:  [7.2665 cpb 7.2638 cpb 7.2607 cpb]
+```
+
+#### Xoodoo[{6, 12}] Permutation
+
+```bash
+xoodoo/6 (cached)       time:   [293.7426 cycles 293.8227 cycles 293.9663 cycles]            
+                        thrpt:  [6.1243 cpb 6.1213 cpb 6.1196 cpb]
+xoodoo/6 (random)       time:   [312.2511 cycles 312.3959 cycles 312.5695 cycles]            
+                        thrpt:  [6.5119 cpb 6.5082 cpb 6.5052 cpb]
+
+xoodoo/12 (cached)      time:   [618.6418 cycles 619.0397 cycles 619.4066 cycles]             
+                        thrpt:  [12.9043 cpb 12.8967 cpb 12.8884 cpb]
+xoodoo/12 (random)      time:   [638.8219 cycles 638.9825 cycles 639.1287 cycles]             
+                        thrpt:  [13.3152 cpb 13.3121 cpb 13.3088 cpb]
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Getting started with using Xoofff - deck function API is fairly easy.
 # either
 xoofff = { git = "https://github.com/itzmeanjan/xoofff" }
 # or
-xoofff = "=0.1.1"
+xoofff = "=0.1.2"
 ```
 
 2) Create Xoofff deck function object.

--- a/benches/xoodoo.rs
+++ b/benches/xoodoo.rs
@@ -2,19 +2,43 @@ use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion
 use rand::{thread_rng, Rng};
 use xoofff::xoodoo;
 
-fn xoodoo<const ROUNDS: usize>(c: &mut Criterion) {
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+use criterion_cycles_per_byte::CyclesPerByte;
+
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+type CriterionHandler = Criterion<CyclesPerByte>;
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+)))]
+type CriterionHandler = Criterion;
+
+fn xoodoo<const ROUNDS: usize>(c: &mut CriterionHandler) {
     let mut rng = thread_rng();
 
     let mut group = c.benchmark_group("xoodoo");
     group.throughput(Throughput::Bytes(48)); // Xoodoo permutation works on 384 -bit wide state
 
-    group.bench_function(format!("xoodoo[{}] (cached)", ROUNDS), |bench| {
+    group.bench_function(format!("{} (cached)", ROUNDS), |bench| {
         let mut state = [0u32; 12];
         rng.fill(&mut state);
 
         bench.iter(|| xoodoo::permute::<{ ROUNDS }>(black_box(&mut state)))
     });
-    group.bench_function(format!("xoodoo[{}] (random)", ROUNDS), |bench| {
+    group.bench_function(format!("{} (random)", ROUNDS), |bench| {
         let mut state = [0u32; 12];
         rng.fill(&mut state);
 
@@ -28,5 +52,20 @@ fn xoodoo<const ROUNDS: usize>(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+criterion_group!(name = permutation; config = Criterion::default().with_measurement(CyclesPerByte); targets = xoodoo::<6>, xoodoo::<12>);
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+)))]
 criterion_group!(permutation, xoodoo::<6>, xoodoo::<12>);
+
 criterion_main!(permutation);

--- a/benches/xoofff.rs
+++ b/benches/xoofff.rs
@@ -2,79 +2,114 @@ use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion
 use rand::{thread_rng, RngCore};
 use xoofff::Xoofff;
 
-fn xoofff<
-    const KLEN: usize,   // deck function key byte length
-    const MLEN: usize,   // to be absorbed message byte length
-    const DLEN: usize,   // to be squeezed output byte length
-    const OFFSET: usize, // deck function offset byte length
->(
-    c: &mut Criterion,
-) {
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+use criterion_cycles_per_byte::CyclesPerByte;
+
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+type CriterionHandler = Criterion<CyclesPerByte>;
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+)))]
+type CriterionHandler = Criterion;
+
+const FIXED_KEY_LEN: usize = 32;
+const MIN_MSG_LEN: usize = 32;
+const MAX_MSG_LEN: usize = 8192;
+const FIXED_DIG_LEN: usize = 32;
+const FIXED_OFFSET: usize = 16;
+
+fn xoofff(c: &mut CriterionHandler) {
     let mut rng = thread_rng();
 
-    let mut group = c.benchmark_group("xoofff");
-    group.throughput(Throughput::Bytes((MLEN + DLEN + OFFSET) as u64));
+    let mut mlen = MIN_MSG_LEN;
+    while mlen <= MAX_MSG_LEN {
+        let mut group = c.benchmark_group("xoofff");
+        group.throughput(Throughput::Bytes(
+            (mlen + FIXED_DIG_LEN + FIXED_OFFSET) as u64,
+        ));
 
-    group.bench_function(
-        format!(
-            "key = {} | in = {} | out = {} | offset = {} (cached)",
-            KLEN, MLEN, DLEN, OFFSET
-        ),
-        |bench| {
-            let mut key = vec![0u8; KLEN];
-            let mut msg = vec![0u8; MLEN];
-            let mut dig = vec![0u8; DLEN];
+        group.bench_function(
+            format!(
+                "key = {}B | in = {}B | out = {}B | offset = {}B (cached)",
+                FIXED_KEY_LEN, mlen, FIXED_DIG_LEN, FIXED_OFFSET
+            ),
+            |bench| {
+                let mut key = vec![0u8; FIXED_KEY_LEN];
+                let mut msg = vec![0u8; mlen];
+                let mut dig = vec![0u8; FIXED_DIG_LEN];
 
-            rng.fill_bytes(&mut key);
-            rng.fill_bytes(&mut msg);
-            rng.fill_bytes(&mut dig);
+                rng.fill_bytes(&mut key);
+                rng.fill_bytes(&mut msg);
+                rng.fill_bytes(&mut dig);
 
-            bench.iter(|| {
-                let mut deck = Xoofff::new(black_box(&key));
-                deck.absorb(black_box(&msg));
-                deck.finalize(black_box(0), black_box(0), black_box(OFFSET));
-                deck.squeeze(black_box(&mut dig));
-            });
-        },
-    );
-
-    group.bench_function(
-        format!(
-            "key = {} | in = {} | out = {} | offset = {} (random)",
-            KLEN, MLEN, DLEN, OFFSET
-        ),
-        |bench| {
-            let mut key = vec![0u8; KLEN];
-            let mut msg = vec![0u8; MLEN];
-            let mut dig = vec![0u8; DLEN];
-
-            rng.fill_bytes(&mut key);
-            rng.fill_bytes(&mut msg);
-            rng.fill_bytes(&mut dig);
-
-            bench.iter_batched(
-                || (key.clone(), msg.clone(), dig.clone()),
-                |(key, msg, mut dig)| {
+                bench.iter(|| {
                     let mut deck = Xoofff::new(black_box(&key));
                     deck.absorb(black_box(&msg));
-                    deck.finalize(black_box(0), black_box(0), black_box(OFFSET));
+                    deck.finalize(black_box(0), black_box(0), black_box(FIXED_OFFSET));
                     deck.squeeze(black_box(&mut dig));
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+                });
+            },
+        );
+
+        group.bench_function(
+            format!(
+                "key = {}B | in = {}B | out = {}B | offset = {}B (random)",
+                FIXED_KEY_LEN, mlen, FIXED_DIG_LEN, FIXED_OFFSET
+            ),
+            |bench| {
+                let mut key = vec![0u8; FIXED_KEY_LEN];
+                let mut msg = vec![0u8; mlen];
+                let mut dig = vec![0u8; FIXED_DIG_LEN];
+
+                rng.fill_bytes(&mut key);
+                rng.fill_bytes(&mut msg);
+                rng.fill_bytes(&mut dig);
+
+                bench.iter_batched(
+                    || (key.clone(), msg.clone(), dig.clone()),
+                    |(key, msg, mut dig)| {
+                        let mut deck = Xoofff::new(black_box(&key));
+                        deck.absorb(black_box(&msg));
+                        deck.finalize(black_box(0), black_box(0), black_box(FIXED_OFFSET));
+                        deck.squeeze(black_box(&mut dig));
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+
+        mlen *= 4;
+    }
 }
 
-criterion_group!(
-    deck_function,
-    xoofff::<32, 32, 32, 16>,
-    xoofff::<32, 64, 32, 16>,
-    xoofff::<32, 128, 32, 16>,
-    xoofff::<32, 256, 32, 16>,
-    xoofff::<32, 512, 32, 16>,
-    xoofff::<32, 1024, 32, 16>,
-    xoofff::<32, 2048, 32, 16>,
-    xoofff::<32, 4096, 32, 16>,
-);
+#[cfg(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+))]
+criterion_group!(name = deck_function; config = Criterion::default().with_measurement(CyclesPerByte); targets = xoofff);
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    target_arch = "x86",
+    target_arch = "aarch64",
+    target_arch = "loongarch64"
+)))]
+criterion_group!(deck_function, xoofff);
+
 criterion_main!(deck_function);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -70,8 +70,8 @@ fn test_xoofff_kat() {
 #[test_case(32, 512, 1024, 0b10101, 5, 8; "key = 32B message = 512B digest = 1024B offset = 8B")]
 #[test_case(32, 1024, 2048, 0, 0, 16; "key = 32B message = 1024B digest = 2048B offset = 16B")]
 #[test_case(47, 2048, 4096, 0b1, 2, 16; "key = 47B message = 1024B digest = 4096B offset = 16B")]
-#[test_case(48, 1024, 32, 0, 0, 32 => panics; "key = 48B message = 1024B digest = 32B offset = 32B")]
-#[test_case(24, 1024, 32, 0, 0, 49 => panics; "key = 24B message = 1024B digest = 32B offset = 49B")]
+#[test_case(48, 1024, 32, 0, 0, 32 => panics "Key byte length must be < 48")]
+#[test_case(24, 1024, 32, 0, 0, 49 => panics "Byte offset, considered during squeezing, must be <= 48 -bytes")]
 fn test_xoofff_incremental_io(
     klen: usize,
     mlen: usize,


### PR DESCRIPTION
- Improve state of benchmarking functions on some targets i.e. x86_64, aarch64 etc.
- Add new benchmark results
